### PR TITLE
Expose compression format

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,7 +1,7 @@
 // Browser and server
 const { CompressionStream, DecompressionStream, Response } = globalThis
 
-type CompressionFormat = 'gzip' | 'deflate' | 'deflate-raw'
+export type CompressionFormat = 'gzip' | 'deflate' | 'deflate-raw'
 
 export async function compress(
   data: string | ArrayBuffer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,23 @@ import {
   compress,
   decompressAsString,
   decompressAsArrayBuffer,
+  CompressionFormat,
 } from './compress.js'
 
-export async function encode(value: any): Promise<string> {
-  return encodeBase64Url(await compress(JSON.stringify(value)))
+export type { CompressionFormat }
+
+export async function encode(value: any, compressionFormat?: CompressionFormat): Promise<string> {
+  return encodeBase64Url(await compress(JSON.stringify(value), compressionFormat))
 }
 
-export async function decode(text: string): Promise<any> {
-  return JSON.parse(await decompressAsString(decodeBase64Url(text)))
+export async function decode(text: string, compressionFormat?: CompressionFormat): Promise<any> {
+  return JSON.parse(await decompressAsString(decodeBase64Url(text), compressionFormat))
 }
 
-export async function encodeBinary(value: ArrayBuffer): Promise<string> {
-  return encodeBase64Url(await compress(value))
+export async function encodeBinary(value: ArrayBuffer, compressionFormat?: CompressionFormat): Promise<string> {
+  return encodeBase64Url(await compress(value, compressionFormat))
 }
 
-export async function decodeBinary(text: string): Promise<ArrayBuffer> {
-  return await decompressAsArrayBuffer(decodeBase64Url(text))
+export async function decodeBinary(text: string, compressionFormat?: CompressionFormat): Promise<ArrayBuffer> {
+  return await decompressAsArrayBuffer(decodeBase64Url(text), compressionFormat)
 }


### PR DESCRIPTION
Hi, thanks for the library, was exactly what I was looking for. :relaxed: 

Here's a pull request to expose the `CompressionFormat` argument to the main function exports.

My use case is that I don't think I need the headers and such in `gzip`, would rather try `deflate-raw` to cut some bytes.